### PR TITLE
Allow custom tags on Advices::CallLogger

### DIFF
--- a/lib/advisor/advices/call_logger.rb
+++ b/lib/advisor/advices/call_logger.rb
@@ -15,9 +15,10 @@ module Advisor
         @method = method
         @call_args = call_args
         @logger = opts[:logger] || CallLogger.default_logger
+        @tag_proc = opts[:with] || ->{}
       end
 
-      attr_reader :object, :method, :call_args, :logger
+      attr_reader :object, :method, :call_args, :logger, :tag_proc
 
       def self.applier_method
         :log_calls_to
@@ -43,7 +44,7 @@ module Advisor
       end
 
       def call_message(prefix, suffix = '')
-        "#{time}#{thread}#{id}#{prefix}\
+        "#{time}#{thread}#{id}#{custom_tag}#{prefix}\
 #{klass}##{method}(#{arguments})\
 #{suffix}"
       end
@@ -54,6 +55,10 @@ module Advisor
 
       def time
         "[Time=#{Time.now}]"
+      end
+
+      def custom_tag
+        object.instance_exec(&tag_proc)
       end
 
       def klass

--- a/spec/advisor/advices/call_logger_spec.rb
+++ b/spec/advisor/advices/call_logger_spec.rb
@@ -40,7 +40,8 @@ Called: OpenStruct#the_meaning_of_life(\"the universe\", \"and everything\")"
           let(:block) { -> () { fail 'deu ruim!' } }
 
           let(:log_message) do
-            /\[Time=#{Time.now}\]\[Thread=#{Thread.current.object_id}\]\
+            /\[Time=#{Regexp.quote(Time.now.to_s)}\]\
+\[Thread=#{Thread.current.object_id}\]\
 \[id=42\]\[x=y\]Failed: OpenStruct#the_meaning_of_life\(\"the universe\", \"and\
  everything\"\).*/
           end

--- a/spec/advisor/advices/call_logger_spec.rb
+++ b/spec/advisor/advices/call_logger_spec.rb
@@ -4,13 +4,14 @@ module Advisor
   module Advices
     describe CallLogger do
       subject(:advice) do
-        described_class.new(object, method, args, logger: logger)
+        described_class.new(object, method, args, logger: logger, with: tag)
       end
 
-      let(:object) { OpenStruct.new(id: 42) }
+      let(:object) { OpenStruct.new(id: 42, x: 'y') }
       let(:method) { 'the_meaning_of_life' }
       let(:args) { ['the universe', 'and everything'] }
       let(:logger) { instance_double(Logger) }
+      let(:tag) { -> { "[x=#{x}]" } }
 
       let(:block) { -> { :bla } }
 
@@ -18,7 +19,7 @@ module Advisor
         subject(:call) { advice.call(&block) }
 
         let(:log_message) do
-          "[Time=#{Time.now}][Thread=#{Thread.current.object_id}][id=42]\
+          "[Time=#{Time.now}][Thread=#{Thread.current.object_id}][id=42][x=y]\
 Called: OpenStruct#the_meaning_of_life(\"the universe\", \"and everything\")"
         end
 
@@ -40,7 +41,7 @@ Called: OpenStruct#the_meaning_of_life(\"the universe\", \"and everything\")"
 
           let(:log_message) do
             /\[Time=#{Time.now}\]\[Thread=#{Thread.current.object_id}\]\
-\[id=42\]Failed: OpenStruct#the_meaning_of_life\(\"the universe\", \"and\
+\[id=42\]\[x=y\]Failed: OpenStruct#the_meaning_of_life\(\"the universe\", \"and\
  everything\"\).*/
           end
 
@@ -89,6 +90,17 @@ Called: OpenStruct#the_meaning_of_life(\"the universe\", \"and everything\")"
                 expect { call }.to raise_error(Exception, 'deu muito ruim!')
               end
             end
+          end
+        end
+
+        context 'when no custom tag is provided' do
+          let(:tag) {}
+          let(:log_without_custom_tag) { log_message.gsub("[x=y]", "") }
+
+          it do
+            expect(logger).to receive(:info).with(log_without_custom_tag)
+
+            call
           end
         end
       end


### PR DESCRIPTION
This MR makes it possible to provide a custom tag to the `CallLogger` advice. Instead of yielding the object to the callable provided, I decided to use an `instance_exec` evaluation to allow a private methods or attributes (which are likely to be useful for logging purposes).