### PR TITLE
Log result

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'advisor'
+
+require 'pry'
+Pry.start

--- a/lib/advisor/advices/call_logger.rb
+++ b/lib/advisor/advices/call_logger.rb
@@ -2,6 +2,28 @@ require 'logger'
 
 module Advisor
   module Advices
+    # A simple built-in logging advise
+    #
+    # == Examples
+    #
+    #   class MyClass
+    #     extend Advisor::Loggable
+    #
+    #     log_calls_to(:simple)
+    #     # [...]Called: MyClass#simple()
+    #
+    #     log_calls_to(:with_result, result: true)
+    #     # [...]Called: MyClass#with_result()
+    #     # [...]Result: MyClass#with_result() => String: "bla"
+    #
+    #     log_calls_to(:with_tag, tag: -> { "[id=#{id}]" }
+    #     # [...][id=42]Called: MyClass#with_tag()
+    #
+    #     log_calls_to(:with_specific_logger, logger: Rails.logger)
+    #     log_calls_to(
+    #       :with_backtrace_cleaner, backtrace_cleaner: CustomCleaner
+    #      )
+    #   end
     class CallLogger
       class << self
         attr_accessor :backtrace_cleaner


### PR DESCRIPTION
## Motivation

There are some scenarios that we also need to log the result of a method call.
## Changes
- Add a new option to `log_calls_to`

``` ruby
log_calls_to :method, result: true

def method
  [1, "2"]
end
```

``` ruby
myclass.method
# [...]Called: MyClass#method()
# [...]Result: MyClass#method() => Array: [1,"2"]
```
- Create a console for testing purposes

``` shell
$ bin/console
[1] pry(main)> Advisor
=> Advisor
```
